### PR TITLE
menu: create criteria table

### DIFF
--- a/json.c
+++ b/json.c
@@ -23,6 +23,49 @@
 
 #include "json.h"
 
+criteria_t content_id_to_criteria[] = {
+    {
+        .content_id = "com.ubuntu.cdimage.daily:ubuntu",
+        .os = "ubuntu",
+        .image_type = "daily-live",
+        .urlbase = "https://cdimage.ubuntu.com",
+        .descriptor = "Ubuntu Desktop",
+    },
+    {
+        .content_id = "com.ubuntu.cdimage.daily:ubuntu-server",
+        .os = "ubuntu-server",
+        .image_type = "daily-live",
+        .urlbase = "https://cdimage.ubuntu.com",
+        .descriptor = "Ubuntu Server",
+    },
+    {
+        .content_id = "com.ubuntu.releases:ubuntu",
+        .os = "ubuntu",
+        .image_type = "desktop",
+        .urlbase = "https://releases.ubuntu.com",
+        .descriptor = "Ubuntu Desktop",
+    },
+    {
+        .content_id = "com.ubuntu.releases:ubuntu-server",
+        .os = "ubuntu-server",
+        .image_type = "live-server",
+        .urlbase = "https://releases.ubuntu.com",
+        .descriptor = "Ubuntu Server",
+    },
+    {} /* must be last */
+};
+
+criteria_t *criteria_for_content_id(const char *content_id)
+{
+    if(!content_id) return NULL;
+    for(int i = 0; content_id_to_criteria[i].content_id; i++) {
+        if(eq(content_id, content_id_to_criteria[i].content_id)) {
+            return &content_id_to_criteria[i];
+        }
+    }
+    return NULL;
+}
+
 json_object *get(json_object *obj, const char *key)
 {
     if(!obj || !key) return NULL;

--- a/json.h
+++ b/json.h
@@ -31,3 +31,28 @@ bool eq(const char *a, const char *b);
 bool lt(const char *a, const char *b);
 
 choices_t *read_iso_choices(char *filename);
+
+/* The criteria is a mapping from a content_id to the information we need to
+ * retrieve, and show info about, a given ISO. Simple stream JSON contains a
+ * content_id on the top level object, which is then used to determine which
+ * ISOs we should look for. */
+typedef struct _criteria_t
+{
+    /* simplestream JSON has at the top level a content_id, which allows table
+     * lookup of other necessary info */
+    const char *content_id;
+
+    /* os and image_type are both needed to uniquely locate the interesting
+     * products */
+    const char *os;
+    const char *image_type;
+
+    /* urlbase is the scheme and host information that needs to be
+     * combined with the product path to obtain the full URL */
+    const char *urlbase;
+    /* descriptor is friendly description of the product,
+     * such as "Ubuntu Server" */
+    const char *descriptor;
+} criteria_t;
+
+criteria_t *criteria_for_content_id(const char *content_id);

--- a/test/test_json.c
+++ b/test/test_json.c
@@ -67,6 +67,45 @@ static void str_NULL(void **state)
     assert_null(str(NULL));
 }
 
+static void criteria_for_content_id_NULL(void **state)
+{
+    assert_null(criteria_for_content_id(NULL));
+}
+
+static void criteria_for_content_id_invalid(void **state)
+{
+    assert_null(criteria_for_content_id("invalid"));
+}
+
+static void criteria_for_content_id_server_cdimage(void **state)
+{
+    criteria_t *criteria = criteria_for_content_id(
+            "com.ubuntu.cdimage.daily:ubuntu-server");
+    assert_non_null(criteria);
+    assert_string_equal(
+            "com.ubuntu.cdimage.daily:ubuntu-server",
+            criteria->content_id);
+    assert_string_equal("ubuntu-server", criteria->os);
+    assert_string_equal("daily-live", criteria->image_type);
+    assert_string_equal("https://cdimage.ubuntu.com", criteria->urlbase);
+    assert_string_equal("Ubuntu Server", criteria->descriptor);
+}
+
+extern criteria_t content_id_to_criteria[];
+
+static void criteria_all_initialized(void **state)
+{
+    for(int i = 0; ; i++) {
+        criteria_t *cur = &content_id_to_criteria[i];
+        if(!cur->content_id) break;
+
+        assert_non_null(cur->os);
+        assert_non_null(cur->image_type);
+        assert_non_null(cur->urlbase);
+        assert_non_null(cur->descriptor);
+    }
+}
+
 char *find_largest_subkey(json_object *obj);
 
 static void find_largest_simple(void **state)
@@ -150,6 +189,11 @@ int main(void)
         cmocka_unit_test(get_good),
         cmocka_unit_test(str_NULL),
         cmocka_unit_test(str_good),
+
+        cmocka_unit_test(criteria_for_content_id_NULL),
+        cmocka_unit_test(criteria_for_content_id_invalid),
+        cmocka_unit_test(criteria_for_content_id_server_cdimage),
+        cmocka_unit_test(criteria_all_initialized),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Given a simple stream JSON, some artifacts are interesting and some are not.  By looking at the content_id in that JSON, we can later filter on the exact product of interest without hardcoding on a given product id, and be flexible about what to show based on that input files have been supplied.