### PR TITLE
Release only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ compile: builddir
 	meson compile
 
 run: compile
-	./builddir/iso-chooser-menu /dev/null test/data/com*json
+	./builddir/iso-chooser-menu /dev/null \
+		test/data/com.ubuntu.releases*json
 
 test: builddir_coverage
 	cd $^

--- a/common.c
+++ b/common.c
@@ -58,26 +58,35 @@ void iso_data_free(iso_data_t *iso_data)
     free(iso_data);
 }
 
-choices_t *choices_create(int len)
+choices_t *choices_create(int capacity)
 {
     choices_t *ret = (choices_t *)calloc(sizeof(choices_t), 1);
     if(!ret) return NULL;
 
-    ret->values = (iso_data_t **)calloc(sizeof(iso_data_t *), len);
+    ret->values = (iso_data_t **)calloc(sizeof(iso_data_t *), capacity);
     if(!ret->values) {
         free(ret);
         return NULL;
     }
-    ret->len = len;
+    ret->capacity = capacity;
     return ret;
 }
 
-void choices_free(choices_t *c)
+void choices_free(choices_t *choices)
 {
-    if(!c) return;
+    if(!choices) return;
 
-    for(int i = 0; i < c->len; i++) {
-        iso_data_free(c->values[i]);
+    for(int i = 0; i < choices->len; i++) {
+        iso_data_free(choices->values[i]);
     }
-    free(c);
+    free(choices);
+}
+
+bool choices_append(choices_t *choices, iso_data_t *data)
+{
+    if(choices->len < choices->capacity) {
+        choices->values[choices->len++] = data;
+        return true;
+    }
+    return false;
 }

--- a/common.h
+++ b/common.h
@@ -23,6 +23,7 @@
 
 #define UNUSED(X) __attribute__((unused(X)))
 
+#include <stdbool.h>
 #include <stdint.h>
 
 typedef struct _iso_data
@@ -35,9 +36,10 @@ typedef struct _iso_data
 
 typedef struct _choices
 {
-    int len;
-    int cur;
-    iso_data_t **values;
+    int capacity; /* number of items allocated in the values array */
+    int cur; /* index of the currently selected choice */
+    int len; /* how many items in the values array actually used */
+    iso_data_t **values; /* data array of iso choices */
 } choices_t;
 
 iso_data_t *iso_data_create(char *label, char *url, char *sha256sum,
@@ -45,6 +47,7 @@ iso_data_t *iso_data_create(char *label, char *url, char *sha256sum,
 void iso_data_free(iso_data_t *iso_data);
 
 choices_t *choices_create(int len);
-void choices_free(choices_t *c);
+void choices_free(choices_t *choices);
+bool choices_append(choices_t *choices, iso_data_t *data);
 
 char *saprintf(char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 mini-iso-tools (0.2.1) UNRELEASED; urgency=medium
 
   * Move build system to meson
+  * Only show the release ISOs for now
 
  -- Dan Bungert <daniel.bungert@canonical.com>  Tue, 21 Feb 2023 17:51:32 -0700
 

--- a/json.h
+++ b/json.h
@@ -55,6 +55,8 @@ typedef struct _criteria_t
 
 criteria_t *criteria_for_content_id(const char *content_id);
 
+bool choices_extend_from_json(choices_t *choices, const char *filename,
+                              const char *arch);
 iso_data_t *get_newest_iso(const char *filename, const char *arch);
 
 json_object *find_largest_key(json_object *obj, const char **ret_key);

--- a/main.c
+++ b/main.c
@@ -72,9 +72,10 @@ typedef enum {
 
 choices_t *read_iso_choices(args_t *args)
 {
-    choices_t *choices = choices_create(args->num_infiles);
+    int capacity = 10;  /* 5 release ISOs * (desktop, server) */
+    choices_t *choices = choices_create(capacity);
     for(int i = 0; i < args->num_infiles; i++) {
-        choices->values[i] = get_newest_iso(args->infiles[i], ARCH);
+        choices_extend_from_json(choices, args->infiles[i], ARCH);
     }
     return choices;
 }

--- a/scripts/iso-menu-session
+++ b/scripts/iso-menu-session
@@ -8,8 +8,6 @@ set -e
 mkdir -p /tmp/mini-iso-menu
 
 urls=""
-urls="$urls https://cdimage.ubuntu.com/streams/v1/com.ubuntu.cdimage.daily:ubuntu-server.json"
-urls="$urls https://cdimage.ubuntu.com/streams/v1/com.ubuntu.cdimage.daily:ubuntu.json"
 urls="$urls https://releases.ubuntu.com/streams/v1/com.ubuntu.releases:ubuntu-server.json"
 urls="$urls https://releases.ubuntu.com/streams/v1/com.ubuntu.releases:ubuntu.json"
 

--- a/test/data/com.ubuntu.releases:ubuntu-server.json
+++ b/test/data/com.ubuntu.releases:ubuntu-server.json
@@ -87,7 +87,7 @@
       "os": "ubuntu-server",
       "release": "jammy",
       "release_codename": "Jammy Jellyfish",
-      "release_title": "22.04.1 LTS",
+      "release_title": "22.04.2 LTS",
       "version": "22.04",
       "versions": {
         "22.04.1": {
@@ -115,6 +115,34 @@
               "path": "jammy/ubuntu-22.04.1-live-server-amd64.manifest",
               "sha256": "b77ce7f712910b4d97217e5e1aa296280060513f742283a8b53b1a8f71c8acfc",
               "size": 18013
+            }
+          }
+        },
+        "22.04.2": {
+          "items": {
+            "iso": {
+              "ftype": "iso",
+              "path": "jammy/ubuntu-22.04.2-live-server-amd64.iso",
+              "sha256": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
+              "size": 1975971840
+            },
+            "iso.zsync": {
+              "ftype": "iso.zsync",
+              "path": "jammy/ubuntu-22.04.2-live-server-amd64.iso.zsync",
+              "sha256": "fd7177c08212011b0ae372ce4472e966bc7bd6479bfb5c7af15988936be73ad3",
+              "size": 3859565
+            },
+            "list": {
+              "ftype": "list",
+              "path": "jammy/ubuntu-22.04.2-live-server-amd64.list",
+              "sha256": "f76163e050a7c5971ddbb92987c7509342accc3ebd4cf4ab6ab7260795853dca",
+              "size": 8035
+            },
+            "manifest": {
+              "ftype": "manifest",
+              "path": "jammy/ubuntu-22.04.2-live-server-amd64.manifest",
+              "sha256": "eca0464aa96da88bb6dd8178cc8b84319be4121233e6f41cccee11d0533e5e25",
+              "size": 18487
             }
           }
         }
@@ -316,5 +344,5 @@
       }
     }
   },
-  "updated": "Thu, 20 Oct 2022 16:23:58 +0000"
+  "updated": "Thu, 23 Feb 2023 18:01:11 +0000"
 }

--- a/test/data/com.ubuntu.releases:ubuntu.json
+++ b/test/data/com.ubuntu.releases:ubuntu.json
@@ -243,7 +243,7 @@
       "os": "ubuntu",
       "release": "jammy",
       "release_codename": "Jammy Jellyfish",
-      "release_title": "22.04.1 LTS",
+      "release_title": "22.04.2 LTS",
       "version": "22.04",
       "versions": {
         "22.04.1": {
@@ -271,6 +271,34 @@
               "path": "jammy/ubuntu-22.04.1-desktop-amd64.manifest",
               "sha256": "b63b7916f415391c441babcd48511f8eaf54e30f76bfa04028231edabeef69c5",
               "size": 59000
+            }
+          }
+        },
+        "22.04.2": {
+          "items": {
+            "iso": {
+              "ftype": "iso",
+              "path": "jammy/ubuntu-22.04.2-desktop-amd64.iso",
+              "sha256": "b98dac940a82b110e6265ca78d1320f1f7103861e922aa1a54e4202686e9bbd3",
+              "size": 4927586304
+            },
+            "iso.zsync": {
+              "ftype": "iso.zsync",
+              "path": "jammy/ubuntu-22.04.2-desktop-amd64.iso.zsync",
+              "sha256": "2fc0edfc85cffe5684f75a135226d32007d75c8f38113694e2ee39b89eae767d",
+              "size": 10827453
+            },
+            "list": {
+              "ftype": "list",
+              "path": "jammy/ubuntu-22.04.2-desktop-amd64.list",
+              "sha256": "6f735216a00f6948d466d618c7c2e74e4b830af45faac27d83579fc45d862109",
+              "size": 24330
+            },
+            "manifest": {
+              "ftype": "manifest",
+              "path": "jammy/ubuntu-22.04.2-desktop-amd64.manifest",
+              "sha256": "6c5b7b0a26f417b6025acebfc6114839885c883c08ca7a3e87542d098655325d",
+              "size": 59931
             }
           }
         }
@@ -316,5 +344,5 @@
       }
     }
   },
-  "updated": "Thu, 20 Oct 2022 16:23:58 +0000"
+  "updated": "Thu, 23 Feb 2023 18:01:11 +0000"
 }

--- a/test/test_json.c
+++ b/test/test_json.c
@@ -204,22 +204,8 @@ static void criteria_all_initialized(void **state)
     }
 }
 
-static void read_NULL(void **state)
-{
-    assert_null(get_newest_iso(NULL, NULL));
-}
-
-static void read_not_exist(void **state)
-{
-    assert_null(get_newest_iso("/not/exist", NULL));
-}
-
-static void read_empty_obj(void **state)
-{
-    assert_null(get_newest_iso("test/data/empty-obj.json", NULL));
-}
-
 static void _test_isodata(
+        int index,
         const char *filename,
         const char *arch,
         const char *expected_label,
@@ -227,7 +213,9 @@ static void _test_isodata(
         const char *expected_sha256sum,
         int64_t expected_size)
 {
-    iso_data_t *iso_data = get_newest_iso(filename, arch);
+    choices_t *choices = choices_create(2);
+    choices_extend_from_json(choices, filename, arch);
+    iso_data_t *iso_data = choices->values[index];
     assert_string_equal(expected_label, iso_data->label);
     assert_string_equal(expected_url, iso_data->url);
     assert_string_equal(expected_sha256sum, iso_data->sha256sum);
@@ -237,6 +225,7 @@ static void _test_isodata(
 static void read_ubuntu_server_cdimage(void **state)
 {
     _test_isodata(
+            0,
             "test/data/com.ubuntu.cdimage.daily:ubuntu-server.json",
             "amd64",
             "Ubuntu Server 23.04 (Lunar Lobster)",
@@ -248,6 +237,7 @@ static void read_ubuntu_server_cdimage(void **state)
 static void read_ubuntu_server_releases(void **state)
 {
     _test_isodata(
+            1,
             "test/data/com.ubuntu.releases:ubuntu-server.json",
             "amd64",
             "Ubuntu Server 22.10 (Kinetic Kudu)",
@@ -259,6 +249,7 @@ static void read_ubuntu_server_releases(void **state)
 static void read_ubuntu_desktop_cdimage(void **state)
 {
     _test_isodata(
+            0,
             "test/data/com.ubuntu.cdimage.daily:ubuntu.json",
             "amd64",
             "Ubuntu Desktop 23.04 (Lunar Lobster)",
@@ -270,6 +261,7 @@ static void read_ubuntu_desktop_cdimage(void **state)
 static void read_ubuntu_desktop_releases(void **state)
 {
     _test_isodata(
+            1,
             "test/data/com.ubuntu.releases:ubuntu.json",
             "amd64",
             "Ubuntu Desktop 22.10 (Kinetic Kudu)",
@@ -290,9 +282,6 @@ int main(void)
         cmocka_unit_test(newest_product_first),
         cmocka_unit_test(newest_product_second),
 
-        cmocka_unit_test(read_NULL),
-        cmocka_unit_test(read_not_exist),
-        cmocka_unit_test(read_empty_obj),
         cmocka_unit_test(read_ubuntu_server_cdimage),
         cmocka_unit_test(read_ubuntu_server_releases),
         cmocka_unit_test(read_ubuntu_desktop_cdimage),


### PR DESCRIPTION
Show the releases info only, instead of cdimage stuff.
Extend JSON handling to be able to read multiple entries from a simplestream.