### PR TITLE
d/control: fix dependency to dhcpcd-base

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mini-iso-tools (0.3.1) noble; urgency=medium
+
+  * Correct depedency declaration on dhcp client, to dhcpcd-base
+
+ -- Dan Bungert <daniel.bungert@canonical.com>  Mon, 25 Mar 2024 08:53:19 -0600
+
 mini-iso-tools (0.3.0) noble; urgency=medium
 
   * Update for more changed ncurses paths, this time to switch to linux-c.

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Depends:
  kexec-tools,
  openssl,
  ca-certificates,
- dhcpcd,
+ dhcpcd-base,
 Description: Show a menu of bootable ISOs
  This package provides hook scripts for the new mini.iso to allow it to
  present a menu of possible boot targets.


### PR DESCRIPTION
dhcpcd is in universe, dhcpcd-base is in main and is sufficient for the initramfs